### PR TITLE
feat(keys): add comprehensive cross-platform key mapping support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,51 @@
-## 0.0.1
+## 1.0.3
 
-* initial implementation
+* **Enhanced Key Mapping System**
+  * Added comprehensive key mappings for all platforms (macOS, Windows, Linux)
+  * Added 47 new key mappings for macOS (total: 103 keys)
+  * Added 39 new key mappings for Windows (total: 95 keys)
+  * Added 39 new key mappings for Linux (total: 95 keys)
 
-## 0.0.2
+* **New Key Support**
+  * All symbol keys (equal, minus, brackets, quote, semicolon, backslash, comma, slash, period, grave)
+  * All numpad digit keys (numPad0-9)
+  * All modifier keys (leftShift, leftAlt, rightShift, rightAlt, capsLock, function)
+  * Extended function keys (F13-F20 for macOS)
+  * Navigation keys (home, end, pageUp, pageDown, help, forwardDelete)
+  * Media keys (volumeUp, volumeDown, mute)
 
-* Fix `Failed to load dynamic library` bug
+* **Documentation**
+  * Completely revamped README with comprehensive examples
+  * Added detailed API reference
+  * Added platform-specific key code usage examples
+  * Improved code examples and usage patterns
+
+## 1.0.2
+
+* Adds `simulateKeyCombination` method for combo keys
+* Renamed `Axis` to `ScrollAxis`
+
+## 1.0.1
+
+* Adds `scrollMouse` method to the plugin
+* Adds more enums
+* Support desktop platforms keyboard keys
+
+## 1.0.0
+
+* Refactor plugin using `Flutter Rust Bridge`
+* Complete rewrite with Rust backend
+* Improved performance and reliability
 
 ## 0.0.3
 
 * Add `MouseButton` enum support
 
-## 1.0.0
+## 0.0.2
 
-* Refactor plugin using `Flutter Rust Bridge`
+* Fix `Failed to load dynamic library` bug
 
-## 1.0.1
+## 0.0.1
 
-* Adds 'scrollMouse' method to the plugin
-* Adds more enums
-* Support desktop platforms keyboard keys
-
-# 1.0.2
-
-* Adds `simulateKeyCombination` method for combo keys
-* Renamed `Axis` to `ScrollAxis`
+* Initial implementation
+* Basic mouse and keyboard simulation

--- a/README.md
+++ b/README.md
@@ -1,15 +1,33 @@
 # 🖱️ Bixat Key Mouse
 
-Cross-platform (Linux, Windows, macOS & BSD) package to simulate keyboard and mouse events
+A powerful cross-platform Flutter plugin for simulating keyboard and mouse events on desktop platforms (Linux, Windows, macOS & BSD). Built with Rust for high performance and reliability.
 
-## Features
+## ✨ Features
 
-- 🖲️ Move mouse to absolute and relative positions
-- 🖱️ Press and release mouse buttons
-- 🖋️ Enter text programmatically
-- ⌨️ Simulate key presses and releases
-- 🗝️ Support for multiple key modifiers
-- 🖥️ Desktop compatibility
+- 🖲️ **Mouse Control**
+  - Move mouse to absolute and relative positions
+  - Press, release, and click mouse buttons (left, middle, right, back, forward)
+  - Scroll mouse horizontally and vertically
+
+- ⌨️ **Keyboard Simulation**
+  - Simulate individual key presses and releases
+  - Execute key combinations (e.g., Ctrl+C, Cmd+V)
+  - Cross-platform key mapping with `UniversalKey` enum
+  - Support for 100+ keys including:
+    - All letters (A-Z)
+    - Numbers (0-9) and numpad keys
+    - Function keys (F1-F20)
+    - Modifiers (Ctrl, Shift, Alt, Command/Win)
+    - Symbols and punctuation
+    - Navigation keys (arrows, home, end, page up/down)
+    - Media keys (volume, mute)
+
+- 📝 **Text Input**
+  - Enter text programmatically
+
+- 🖥️ **Desktop Compatibility**
+  - Seamless cross-platform support
+  - Platform-specific key code management
 
 ## Installation
 
@@ -24,167 +42,296 @@ Then run `flutter pub get` to install the package.
 ## Supported Platforms
 
 | Platform | Tested |
-|----------|--------|
-| Linux    | No    |
-| Windows  | No    |
+| -------- | ------ |
+| Linux    | No     |
+| Windows  | No     |
 | macOS    | Yes    |
 | BSD      | No     |
 
 
-## Getting Started
+## 🚀 Getting Started
 
-To use Bixat Key Mouse in your Dart code, import the package:
+### Initialization
 
-```dart
-import 'package:bixat_key_mouse/bixat_key_mouse.dart';
-```
-
-## Basic Usage
-
-Here's a simple example demonstrating various functionalities:
+Before using the plugin, initialize it in your app:
 
 ```dart
 import 'package:bixat_key_mouse/bixat_key_mouse.dart';
 
-void main() {
-  // Move mouse to absolute position 🖱️
-  BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.absolute);
-
-  // Move mouse relative to current position ➡️
-  BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.relative);
-
-  // Click left mouse button 🖱️
-  BixatKeyMouse.pressMouseButton(
-    button: MouseButton.left,
-    direction: Direction.click,
-  );
-
-  // Press left mouse button 🖱️
-  BixatKeyMouse.pressMouseButton(
-    button: MouseButton.left,
-    direction: Direction.press,
-  );
-
-  // Release left mouse button 🖱️
-  BixatKeyMouse.pressMouseButton(
-    button: MouseButton.left,
-    direction: Direction.release,
-  );
-
-  // Enter text 🖋️
-  final text = 'Hello, world!';
-  BixatKeyMouse.enterText(text);
-
-  // Simulate key press ⌨️
-  final key = UniversalKey.leftCommand;
-  BixatKeyMouse.simulateKeyPress(key);
-
-  // Release key ⌨️
-  final keyRelease = UniversalKey.capsLock;
-  BixatKeyMouse.simulateKeyPress(keyRelease, direction: Direction.release);
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await BixatKeyMouse.initialize();
+  runApp(MyApp());
 }
 ```
 
-## Available Functions
+## 📖 Usage Examples
 
 ### Mouse Control
 
-#### moveMouseAbs(int x, int y)
-Move the mouse cursor to an absolute position on the screen. 📍
-
 ```dart
-BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.absolute);
-```
+// Move mouse to absolute position (x: 100, y: 200)
+BixatKeyMouse.moveMouse(
+  x: 100,
+  y: 200,
+  coordinate: Coordinate.absolute,
+);
 
-#### moveMouseRel(int dx, int dy)
-Move the mouse cursor relative to its current position. ➡️
+// Move mouse relative to current position
+BixatKeyMouse.moveMouse(
+  x: 50,
+  y: -30,
+  coordinate: Coordinate.relative,
+);
 
-```dart
-BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.relative);
-```
+// Click left mouse button
+BixatKeyMouse.pressMouseButton(
+  button: MouseButton.left,
+  direction: Direction.click,
+);
 
-#### pressMouseButton(int button)
-Press the specified mouse button. 🖱️
+// Press and hold right mouse button
+BixatKeyMouse.pressMouseButton(
+  button: MouseButton.right,
+  direction: Direction.press,
+);
 
-```dart
-BixatKeyMouse.pressMouseButton(MouseButton.left); // Left mouse button
-BixatKeyMouse.pressMouseButton(MouseButton.middle); // Middle mouse button
-BixatKeyMouse.pressMouseButton(MouseButton.right); // Right mouse button
-```
-
-#### releaseMouseButton(int button)
-Release the specified mouse button. 🖱️
-
-```dart
+// Release mouse button
 BixatKeyMouse.pressMouseButton(
   button: MouseButton.left,
   direction: Direction.release,
+);
+
+// Scroll mouse vertically
+BixatKeyMouse.scrollMouse(
+  distance: 5,
+  axis: ScrollAxis.vertical,
+);
+
+// Scroll mouse horizontally
+BixatKeyMouse.scrollMouse(
+  distance: -3,
+  axis: ScrollAxis.horizontal,
+);
+```
+
+### Keyboard Simulation
+
+```dart
+// Press a single key
+BixatKeyMouse.simulateKey(
+  key: UniversalKey.a,
+  direction: Direction.press,
+);
+
+// Release a key
+BixatKeyMouse.simulateKey(
+  key: UniversalKey.a,
+  direction: Direction.release,
+);
+
+// Click a key (press and release)
+BixatKeyMouse.simulateKey(
+  key: UniversalKey.enter,
+  direction: Direction.click,
+);
+
+// Simulate key combination (e.g., Ctrl+C)
+BixatKeyMouse.simulateKeyCombination(
+  keys: [UniversalKey.leftControl, UniversalKey.c],
+  duration: Duration(milliseconds: 100),
+);
+
+// Simulate Cmd+V on macOS or Ctrl+V on Windows/Linux
+BixatKeyMouse.simulateKeyCombination(
+  keys: [UniversalKey.leftCommand, UniversalKey.v],
+  duration: Duration(milliseconds: 50),
 );
 ```
 
 ### Text Input
 
-#### enterText(String text)
-Enter text programmatically. 📜
-
 ```dart
-final text = 'Hello, world!';
-BixatKeyMouse.enterText(text);
+// Enter text programmatically
+BixatKeyMouse.enterText(text: 'Hello, World!');
+
+// Type a sentence
+BixatKeyMouse.enterText(text: 'This is automated text input.');
 ```
 
-### Keyboard Simulation
+## 📚 API Reference
 
-#### simulateKeyPress(UniversalKey modifier, {Direction direction = Direction.press})
-Simulate key press. ⌨️
+### Core Methods
+
+#### `initialize()`
+Initialize the Rust library. Must be called before using any other methods.
 
 ```dart
-final key = UniversalKey.leftCommand;
-BixatKeyMouse.simulateKeyPress(key);
+await BixatKeyMouse.initialize();
 ```
 
-#### simulateKeyPress(UniversalKey modifier, {Direction direction = Direction.release})
-Simulate key release. ⌨️
+#### `moveMouse({required int x, required int y, Coordinate coordinate})`
+Move the mouse cursor to a position.
+
+**Parameters:**
+- `x`: X coordinate
+- `y`: Y coordinate
+- `coordinate`: `Coordinate.absolute` or `Coordinate.relative` (default: `absolute`)
+
+#### `pressMouseButton({required MouseButton button, Direction direction})`
+Control mouse button actions.
+
+**Parameters:**
+- `button`: Mouse button (`left`, `middle`, `right`, `back`, `forward`, `scrollUp`, `scrollDown`, `scrollLeft`, `scrollRight`)
+- `direction`: Action type (`press`, `release`, `click`) (default: `press`)
+
+#### `scrollMouse({required int distance, ScrollAxis axis})`
+Scroll the mouse wheel.
+
+**Parameters:**
+- `distance`: Scroll distance (positive or negative)
+- `axis`: Scroll direction (`horizontal` or `vertical`) (default: `horizontal`)
+
+#### `simulateKey({required UniversalKey key, Direction direction})`
+Simulate a keyboard key action.
+
+**Parameters:**
+- `key`: The key to simulate (see `UniversalKey` enum)
+- `direction`: Action type (`press`, `release`, `click`) (default: `press`)
+
+#### `simulateKeyCombination({required List<UniversalKey> keys, Duration duration})`
+Simulate a key combination (e.g., Ctrl+C).
+
+**Parameters:**
+- `keys`: List of keys to press simultaneously
+- `duration`: How long to hold the keys (default: `100ms`)
+
+#### `enterText({required String text})`
+Type text programmatically.
+
+**Parameters:**
+- `text`: The text to type
+
+### Enums
+
+#### `MouseButton`
+- `left`, `middle`, `right`, `back`, `forward`
+- `scrollUp`, `scrollDown`, `scrollLeft`, `scrollRight`
+
+#### `Direction`
+- `press` - Press and hold
+- `release` - Release a pressed key/button
+- `click` - Press and immediately release
+
+#### `Coordinate`
+- `absolute` - Absolute screen position
+- `relative` - Relative to current position
+
+#### `ScrollAxis`
+- `horizontal` - Scroll left/right
+- `vertical` - Scroll up/down
+
+#### `UniversalKey`
+Cross-platform key identifiers. Includes:
+- Letters: `a` to `z`
+- Numbers: `num0` to `num9`
+- Numpad: `numPad0` to `numPad9`, `numPadAdd`, `numPadSubtract`, etc.
+- Function keys: `f1` to `f20`
+- Modifiers: `leftControl`, `leftShift`, `leftAlt`, `leftCommand`, `rightControl`, etc.
+- Symbols: `equal`, `minus`, `leftBracket`, `rightBracket`, `quote`, etc.
+- Navigation: `arrowLeft`, `arrowRight`, `arrowUp`, `arrowDown`, `home`, `end`, `pageUp`, `pageDown`
+- Special: `returnKey`, `tab`, `space`, `delete`, `escape`, `capsLock`, `function`
+- Media: `volumeUp`, `volumeDown`, `mute`
+
+## 🔧 Advanced Usage
+
+### Complex Automation Example
 
 ```dart
-final keyRelease = UniversalKey.capsLock;
-BixatKeyMouse.simulateKeyPress(keyRelease);
+// Automate a copy-paste operation
+await Future.delayed(Duration(seconds: 1));
+
+// Select all text (Ctrl+A / Cmd+A)
+BixatKeyMouse.simulateKeyCombination(
+  keys: [UniversalKey.leftCommand, UniversalKey.a],
+);
+
+await Future.delayed(Duration(milliseconds: 100));
+
+// Copy (Ctrl+C / Cmd+C)
+BixatKeyMouse.simulateKeyCombination(
+  keys: [UniversalKey.leftCommand, UniversalKey.c],
+);
+
+await Future.delayed(Duration(milliseconds: 100));
+
+// Move to another location
+BixatKeyMouse.moveMouse(x: 500, y: 300, coordinate: Coordinate.absolute);
+BixatKeyMouse.pressMouseButton(button: MouseButton.left, direction: Direction.click);
+
+// Paste (Ctrl+V / Cmd+V)
+BixatKeyMouse.simulateKeyCombination(
+  keys: [UniversalKey.leftCommand, UniversalKey.v],
+);
 ```
 
-## Advanced Usage
+### Platform-Specific Key Codes
 
-### Combining Functions
-
-You can combine mouse movements and key presses for complex interactions: 🔄
+The plugin automatically handles platform-specific key codes:
 
 ```dart
-BixatKeyMouse.moveMouseAbs(100, 100);
-BixatKeyMouse.pressMouseButton(1);
-// Perform actions...
-BixatKeyMouse.releaseMouseButton(1);
-```
+// This works on all platforms
+BixatKeyMouse.simulateKey(key: UniversalKey.leftCommand);
 
-### Handling Exceptions
+// On macOS: Uses Command key
+// On Windows/Linux: Uses Windows/Super key
 
-The package throws exceptions when certain operations fail. It's recommended to handle these exceptions: ⚠️
-
-```dart
-try {
-  BixatKeyMouse.moveMouseAbs(100, 100);
-} catch (e) {
-  print('Error moving mouse: $e');
+// Check if a key is supported on current platform
+if (UniversalKey.f13.isSupported) {
+  BixatKeyMouse.simulateKey(key: UniversalKey.f13);
 }
+
+// Get platform-specific key code
+int keyCode = UniversalKey.a.code;
 ```
 
-## Acknowledgements
+## 🏗️ Architecture
 
-The Bixat Key Mouse package utilizes the [Enigo](https://crates.io/crates/enigo) crate for simulating keyboard and mouse events across different platforms. Enigo is a Rust library that provides a cross-platform abstraction for controlling keyboards and mice, making it a valuable underlying tool for this package. 🎉
+This plugin is built using:
 
-In addition, the [Flutter Rust Bridge](https://github.com/fzyzcjy/flutter_rust_bridge) tool is used to facilitate seamless communication between Flutter and Rust, allowing efficient and safe function calls across language boundaries. This integration leverages Rust's performance and safety with Flutter's flexibility, further enhancing the package's capabilities. 🌉
+- **[Flutter Rust Bridge](https://github.com/fzyzcjy/flutter_rust_bridge)** - Seamless Dart-Rust interop
+- **[Enigo](https://crates.io/crates/enigo)** - Cross-platform input simulation in Rust
+- **[Cargokit](https://github.com/irondash/cargokit)** - Rust build integration for Flutter
 
-## Contributing
+The architecture leverages Rust's performance and safety while maintaining Flutter's ease of use.
 
-Contributions are welcome! Please feel free to submit a Pull Request. 🤝
+## 🤝 Contributing
 
-## License
+Contributions are welcome! Please feel free to:
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details. 📜
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## 📝 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## 🙏 Acknowledgements
+
+Special thanks to:
+- The [Enigo](https://crates.io/crates/enigo) team for the excellent cross-platform input simulation library
+- The [Flutter Rust Bridge](https://github.com/fzyzcjy/flutter_rust_bridge) project for making Dart-Rust integration seamless
+- All contributors and users of this package
+
+## 📞 Support
+
+- 🐛 [Report Issues](https://github.com/bixat/bixat_key_mouse/issues)
+- � [Discussions](https://github.com/bixat/bixat_key_mouse/discussions)
+- 🌐 [Website](https://bixat.dev)
+
+---
+
+Made with ❤️ by the Bixat team

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,21 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:bixat_key_mouse/bixat_key_mouse.dart';
 
+/// Bixat Key Mouse Demo Application
+///
+/// This example demonstrates all features of the bixat_key_mouse plugin:
+/// - Mouse movement (absolute and relative)
+/// - Mouse button actions (click, press, release)
+/// - Mouse scrolling (horizontal and vertical)
+/// - Keyboard simulation (individual keys and combinations)
+/// - Text input automation
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Initialize the Rust library before using the plugin
   await BixatKeyMouse.initialize();
+
   runApp(const MyApp());
 }
 
@@ -12,8 +25,12 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'BixatKeyMouse Demo',
-      theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
+      title: 'Bixat Key Mouse Demo',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
       home: const BixatKeyMouseDemo(),
     );
   }
@@ -26,383 +43,473 @@ class BixatKeyMouseDemo extends StatefulWidget {
   State<BixatKeyMouseDemo> createState() => _BixatKeyMouseDemoState();
 }
 
-class _BixatKeyMouseDemoState extends State<BixatKeyMouseDemo> {
-  final TextEditingController _xController = TextEditingController(text: '100');
-  final TextEditingController _yController = TextEditingController(text: '100');
-  final TextEditingController _textController = TextEditingController();
-  final TextEditingController _keyController = TextEditingController();
+class _BixatKeyMouseDemoState extends State<BixatKeyMouseDemo>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
 
-  String _statusMessage = 'Ready';
+  final TextEditingController _xController = TextEditingController(text: '500');
+  final TextEditingController _yController = TextEditingController(text: '500');
+  final TextEditingController _textController = TextEditingController(
+    text: 'Hello from Bixat Key Mouse!',
+  );
+  final TextEditingController _scrollController = TextEditingController(
+    text: '5',
+  );
 
-  void _updateStatus(String message) {
+  String _statusMessage = '✅ Ready - Plugin initialized successfully';
+  Color _statusColor = Colors.green;
+  UniversalKey _selectedKey = UniversalKey.a;
+  Direction _selectedDirection = Direction.click;
+  ScrollAxis _selectedScrollAxis = ScrollAxis.vertical;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 5, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _xController.dispose();
+    _yController.dispose();
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _updateStatus(String message, {bool isError = false}) {
     setState(() {
-      _statusMessage = message;
+      _statusMessage = isError ? '❌ $message' : '✅ $message';
+      _statusColor = isError ? Colors.red : Colors.green;
     });
   }
 
-  // Mouse movement functions
+  // ==================== Mouse Functions ====================
+
   void _moveMouseAbsolute() {
     try {
-      int x = int.parse(_xController.text);
-      int y = int.parse(_yController.text);
-      BixatKeyMouse.moveMouse(x: x, y: y);
-      _updateStatus('Mouse moved to ($x, $y)');
+      final x = int.parse(_xController.text);
+      final y = int.parse(_yController.text);
+      BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.absolute);
+      _updateStatus('Mouse moved to absolute position ($x, $y)');
     } catch (e) {
-      _updateStatus('Error: Invalid coordinates');
+      _updateStatus('Invalid coordinates: $e', isError: true);
     }
   }
 
   void _moveMouseRelative() {
     try {
-      int x = int.parse(_xController.text);
-      int y = int.parse(_yController.text);
+      final x = int.parse(_xController.text);
+      final y = int.parse(_yController.text);
       BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.relative);
-      _updateStatus('Mouse moved by ($x, $y)');
+      _updateStatus('Mouse moved by relative offset ($x, $y)');
     } catch (e) {
-      _updateStatus('Error: Invalid coordinates');
+      _updateStatus('Invalid coordinates: $e', isError: true);
     }
   }
 
-  // Mouse button functions
-  void _leftClick() {
-    BixatKeyMouse.pressMouseButton(button: MouseButton.left);
+  void _performMouseAction(MouseButton button, Direction direction) {
+    BixatKeyMouse.pressMouseButton(button: button, direction: direction);
+    _updateStatus('${button.name} button ${direction.name}');
+  }
+
+  void _performDoubleClick() async {
     BixatKeyMouse.pressMouseButton(
       button: MouseButton.left,
-      direction: Direction.release,
+      direction: Direction.click,
     );
-    _updateStatus('Left click performed');
-  }
-
-  void _rightClick() {
-    BixatKeyMouse.pressMouseButton(button: MouseButton.right);
-    BixatKeyMouse.pressMouseButton(
-      button: MouseButton.right,
-      direction: Direction.release,
-    );
-    _updateStatus('Right click performed');
-  }
-
-  void _middleClick() {
-    BixatKeyMouse.pressMouseButton(button: MouseButton.middle);
-    BixatKeyMouse.pressMouseButton(
-      button: MouseButton.middle,
-      direction: Direction.release,
-    );
-    _updateStatus('Middle click performed');
-  }
-
-  void _scrollMouse() {
-    BixatKeyMouse.scrollMouse(axis: ScrollAxis.vertical, distance: 100);
-    _updateStatus('Scroll Down performed');
-  }
-
-  // Keyboard functions
-  void _typeText() {
-    if (_textController.text.isNotEmpty) {
-      BixatKeyMouse.enterText(text: _textController.text);
-      _updateStatus('Text typed: "${_textController.text}"');
-    } else {
-      _updateStatus('Please enter some text');
-    }
-  }
-
-  void _pressKey() {
-    if (_keyController.text.isNotEmpty) {
-      BixatKeyMouse.simulateKey(key: UniversalKey.rightControl);
-      _updateStatus('Key pressed: ${UniversalKey.rightControl.name}');
-    } else {
-      _updateStatus('Please enter a key');
-    }
-  }
-
-  void _releaseKey() {
-    if (_keyController.text.isNotEmpty) {
-      BixatKeyMouse.simulateKey(key: UniversalKey.rightControl);
-      _updateStatus('Key released: ${UniversalKey.rightControl.name}');
-    } else {
-      _updateStatus('Please enter a key');
-    }
-  }
-
-  // Predefined actions
-  void _performDoubleClick() {
-    BixatKeyMouse.pressMouseButton(button: MouseButton.left);
+    await Future.delayed(const Duration(milliseconds: 50));
     BixatKeyMouse.pressMouseButton(
       button: MouseButton.left,
-      direction: Direction.release,
+      direction: Direction.click,
     );
-    Future.delayed(const Duration(milliseconds: 100), () {
-      BixatKeyMouse.pressMouseButton(button: MouseButton.left);
-      BixatKeyMouse.pressMouseButton(
-        button: MouseButton.left,
-        direction: Direction.release,
-      );
-    });
     _updateStatus('Double click performed');
   }
 
-  Future<void> _performKeyCombo() async {
-    // Simulate Command+Space
+  void _scrollMouse() {
+    try {
+      final distance = int.parse(_scrollController.text);
+      BixatKeyMouse.scrollMouse(distance: distance, axis: _selectedScrollAxis);
+      _updateStatus('Scrolled ${_selectedScrollAxis.name} by $distance');
+    } catch (e) {
+      _updateStatus('Invalid scroll distance: $e', isError: true);
+    }
+  }
+
+  // ==================== Keyboard Functions ====================
+
+  void _simulateKey() {
+    BixatKeyMouse.simulateKey(key: _selectedKey, direction: _selectedDirection);
+    _updateStatus('Key ${_selectedKey.name} ${_selectedDirection.name}');
+  }
+
+  void _typeText() {
+    if (_textController.text.isEmpty) {
+      _updateStatus('Please enter some text', isError: true);
+      return;
+    }
+    BixatKeyMouse.enterText(text: _textController.text);
+    _updateStatus('Typed: "${_textController.text}"');
+  }
+
+  // ==================== Key Combination Functions ====================
+
+  Future<void> _performCopyPaste() async {
+    final modifierKey = Platform.isMacOS
+        ? UniversalKey.leftCommand
+        : UniversalKey.leftControl;
+
+    // Select all
     BixatKeyMouse.simulateKeyCombination(
-      keys: [UniversalKey.rightCommand, UniversalKey.space],
+      keys: [modifierKey, UniversalKey.a],
+      duration: const Duration(milliseconds: 50),
     );
-    _updateStatus('Command+Space performed');
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    // Copy
+    BixatKeyMouse.simulateKeyCombination(
+      keys: [modifierKey, UniversalKey.c],
+      duration: const Duration(milliseconds: 50),
+    );
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    // Paste
+    BixatKeyMouse.simulateKeyCombination(
+      keys: [modifierKey, UniversalKey.v],
+      duration: const Duration(milliseconds: 50),
+    );
+
+    _updateStatus('Copy-Paste sequence completed');
+  }
+
+  Future<void> _performCustomCombo(
+    List<UniversalKey> keys,
+    String description,
+  ) async {
+    BixatKeyMouse.simulateKeyCombination(
+      keys: keys,
+      duration: const Duration(milliseconds: 100),
+    );
+    _updateStatus(description);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('BixatKeyMouse Demo'),
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: const Text('🖱️ Bixat Key Mouse Demo'),
+        bottom: TabBar(
+          controller: _tabController,
+          isScrollable: true,
+          tabs: const [
+            Tab(icon: Icon(Icons.mouse), text: 'Mouse Movement'),
+            Tab(icon: Icon(Icons.touch_app), text: 'Mouse Buttons'),
+            Tab(icon: Icon(Icons.keyboard), text: 'Keyboard'),
+            Tab(icon: Icon(Icons.text_fields), text: 'Text Input'),
+            Tab(icon: Icon(Icons.auto_awesome), text: 'Automation'),
+          ],
+        ),
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
+      body: Column(
+        children: [
+          // Status Bar
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            color: _statusColor.withValues(alpha: 0.1),
+            child: Row(
+              children: [
+                Icon(
+                  _statusColor == Colors.green
+                      ? Icons.check_circle
+                      : Icons.error,
+                  color: _statusColor,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _statusMessage,
+                    style: TextStyle(
+                      color: _statusColor,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Tab Content
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                _buildMouseMovementTab(),
+                _buildMouseButtonsTab(),
+                _buildKeyboardTab(),
+                _buildTextInputTab(),
+                _buildAutomationTab(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ==================== Tab Builders ====================
+
+  Widget _buildMouseMovementTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            '🖱️ Mouse Movement',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Control mouse cursor position using absolute or relative coordinates.',
+            style: TextStyle(color: Colors.grey),
+          ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _xController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'X Coordinate',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.arrow_forward),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: TextField(
+                  controller: _yController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'Y Coordinate',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.arrow_downward),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: _moveMouseAbsolute,
+            icon: const Icon(Icons.gps_fixed),
+            label: const Text('Move to Absolute Position'),
+            style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(16)),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton.icon(
+            onPressed: _moveMouseRelative,
+            icon: const Icon(Icons.open_with),
+            label: const Text('Move by Relative Offset'),
+            style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(16)),
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text(
+            'Quick Movement Presets',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildPresetButton('Top Left', 0, 0),
+              _buildPresetButton('Top Right', 1920, 0),
+              _buildPresetButton('Center', 960, 540),
+              _buildPresetButton('Bottom Left', 0, 1080),
+              _buildPresetButton('Bottom Right', 1920, 1080),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPresetButton(String label, int x, int y) {
+    return ElevatedButton(
+      onPressed: () {
+        BixatKeyMouse.moveMouse(x: x, y: y, coordinate: Coordinate.absolute);
+        _updateStatus('Mouse moved to $label ($x, $y)');
+      },
+      child: Text(label),
+    );
+  }
+
+  Widget _buildMouseButtonsTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            '🖱️ Mouse Buttons & Scrolling',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Simulate mouse button clicks and scroll wheel actions.',
+            style: TextStyle(color: Colors.grey),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            'Mouse Buttons',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          _buildMouseButtonCard(
+            'Left Button',
+            Icons.mouse,
+            MouseButton.left,
+            Colors.blue,
+          ),
+          const SizedBox(height: 12),
+          _buildMouseButtonCard(
+            'Right Button',
+            Icons.mouse,
+            MouseButton.right,
+            Colors.orange,
+          ),
+          const SizedBox(height: 12),
+          _buildMouseButtonCard(
+            'Middle Button',
+            Icons.mouse,
+            MouseButton.middle,
+            Colors.green,
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton.icon(
+            onPressed: _performDoubleClick,
+            icon: const Icon(Icons.touch_app),
+            label: const Text('Double Click'),
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.all(16),
+              backgroundColor: Colors.purple,
+              foregroundColor: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text(
+            'Mouse Scrolling',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _scrollController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'Scroll Distance',
+                    border: OutlineInputBorder(),
+                    helperText: 'Positive = down/right, Negative = up/left',
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: DropdownButtonFormField<ScrollAxis>(
+                  initialValue: _selectedScrollAxis,
+                  decoration: const InputDecoration(
+                    labelText: 'Scroll Axis',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: ScrollAxis.values.map((axis) {
+                    return DropdownMenuItem(
+                      value: axis,
+                      child: Text(axis.name.toUpperCase()),
+                    );
+                  }).toList(),
+                  onChanged: (value) {
+                    setState(() {
+                      _selectedScrollAxis = value!;
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: _scrollMouse,
+            icon: const Icon(Icons.swap_vert),
+            label: const Text('Scroll Mouse'),
+            style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(16)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMouseButtonCard(
+    String title,
+    IconData icon,
+    MouseButton button,
+    Color color,
+  ) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Status display
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    const Text(
-                      'Status',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      _statusMessage,
-                      style: const TextStyle(fontSize: 16),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
+            Row(
+              children: [
+                Icon(icon, color: color),
+                const SizedBox(width: 8),
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
-              ),
+              ],
             ),
-            const SizedBox(height: 20),
-
-            // Mouse controls
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    const Text(
-                      'Mouse Controls',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextField(
-                            controller: _xController,
-                            keyboardType: TextInputType.number,
-                            decoration: const InputDecoration(
-                              labelText: 'X Position',
-                              border: OutlineInputBorder(),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        Expanded(
-                          child: TextField(
-                            controller: _yController,
-                            keyboardType: TextInputType.number,
-                            decoration: const InputDecoration(
-                              labelText: 'Y Position',
-                              border: OutlineInputBorder(),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _moveMouseAbsolute,
-                            child: const Text('Move Absolute'),
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _moveMouseRelative,
-                            child: const Text('Move Relative'),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _leftClick,
-                            child: const Text('Left Click'),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _rightClick,
-                            child: const Text('Right Click'),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _middleClick,
-                            child: const Text('Middle Click'),
-                          ),
-                        ),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _scrollMouse,
-                            child: const Text('Scroll Down'),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    ElevatedButton(
-                      onPressed: _performDoubleClick,
-                      child: const Text('Double Click'),
-                    ),
-                  ],
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () =>
+                        _performMouseAction(button, Direction.click),
+                    child: const Text('Click'),
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(height: 20),
-
-            // Keyboard controls
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    const Text(
-                      'Keyboard Controls',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    TextField(
-                      controller: _textController,
-                      decoration: const InputDecoration(
-                        labelText: 'Text to Type',
-                        border: OutlineInputBorder(),
-                        hintText: 'Enter text here...',
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    ElevatedButton(
-                      onPressed: _typeText,
-                      child: const Text('Type Text'),
-                    ),
-                    const SizedBox(height: 16),
-                    TextField(
-                      controller: _keyController,
-                      decoration: const InputDecoration(
-                        labelText: 'Key Name',
-                        border: OutlineInputBorder(),
-                        hintText: 'e.g., enter, space, ctrl, alt',
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _pressKey,
-                            child: const Text('Press Key'),
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        Expanded(
-                          child: ElevatedButton(
-                            onPressed: _releaseKey,
-                            child: const Text('Release Key'),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    ElevatedButton(
-                      onPressed: _performKeyCombo,
-                      child: const Text('Command+Space Combo'),
-                    ),
-                  ],
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () =>
+                        _performMouseAction(button, Direction.press),
+                    child: const Text('Press'),
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(height: 20),
-
-            // Quick actions
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    const Text(
-                      'Quick Actions',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        ElevatedButton(
-                          onPressed: () {
-                            BixatKeyMouse.simulateKey(
-                              key: UniversalKey.numPadEnter,
-                            );
-                            _updateStatus('Enter key pressed');
-                          },
-                          child: const Text('Enter'),
-                        ),
-                        ElevatedButton(
-                          onPressed: () {
-                            BixatKeyMouse.simulateKey(key: UniversalKey.space);
-                            _updateStatus('Space key pressed');
-                          },
-                          child: const Text('Space'),
-                        ),
-                        ElevatedButton(
-                          onPressed: () {
-                            BixatKeyMouse.simulateKey(key: UniversalKey.tab);
-                            _updateStatus('Tab key pressed');
-                          },
-                          child: const Text('Tab'),
-                        ),
-                        ElevatedButton(
-                          onPressed: () {
-                            BixatKeyMouse.simulateKey(key: UniversalKey.escape);
-                            _updateStatus('Escape key pressed');
-                          },
-                          child: const Text('Escape'),
-                        ),
-                      ],
-                    ),
-                  ],
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () =>
+                        _performMouseAction(button, Direction.release),
+                    child: const Text('Release'),
+                  ),
                 ),
-              ),
+              ],
             ),
           ],
         ),
@@ -410,12 +517,425 @@ class _BixatKeyMouseDemoState extends State<BixatKeyMouseDemo> {
     );
   }
 
-  @override
-  void dispose() {
-    _xController.dispose();
-    _yController.dispose();
-    _textController.dispose();
-    _keyController.dispose();
-    super.dispose();
+  Widget _buildKeyboardTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            '⌨️ Keyboard Simulation',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Simulate individual key presses, releases, and clicks.',
+            style: TextStyle(color: Colors.grey),
+          ),
+          const SizedBox(height: 24),
+          DropdownButtonFormField<UniversalKey>(
+            initialValue: _selectedKey,
+            decoration: const InputDecoration(
+              labelText: 'Select Key',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.keyboard),
+            ),
+            items: _getCommonKeys().map((key) {
+              return DropdownMenuItem(
+                value: key,
+                child: Text(key.name.toUpperCase()),
+              );
+            }).toList(),
+            onChanged: (value) {
+              setState(() {
+                _selectedKey = value!;
+              });
+            },
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<Direction>(
+            initialValue: _selectedDirection,
+            decoration: const InputDecoration(
+              labelText: 'Action Type',
+              border: OutlineInputBorder(),
+              prefixIcon: Icon(Icons.touch_app),
+            ),
+            items: Direction.values.map((direction) {
+              return DropdownMenuItem(
+                value: direction,
+                child: Text(direction.name.toUpperCase()),
+              );
+            }).toList(),
+            onChanged: (value) {
+              setState(() {
+                _selectedDirection = value!;
+              });
+            },
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: _simulateKey,
+            icon: const Icon(Icons.keyboard_alt),
+            label: Text(
+              'Simulate ${_selectedKey.name} ${_selectedDirection.name}',
+            ),
+            style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(16)),
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text(
+            'Quick Key Actions',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildQuickKeyButton('Enter', UniversalKey.returnKey),
+              _buildQuickKeyButton('Space', UniversalKey.space),
+              _buildQuickKeyButton('Tab', UniversalKey.tab),
+              _buildQuickKeyButton('Escape', UniversalKey.escape),
+              _buildQuickKeyButton('Delete', UniversalKey.delete),
+              _buildQuickKeyButton('↑', UniversalKey.arrowUp),
+              _buildQuickKeyButton('↓', UniversalKey.arrowDown),
+              _buildQuickKeyButton('←', UniversalKey.arrowLeft),
+              _buildQuickKeyButton('→', UniversalKey.arrowRight),
+            ],
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text(
+            'Modifier Keys',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildQuickKeyButton('Ctrl', UniversalKey.leftControl),
+              _buildQuickKeyButton('Shift', UniversalKey.leftShift),
+              _buildQuickKeyButton('Alt', UniversalKey.leftAlt),
+              _buildQuickKeyButton(
+                Platform.isMacOS ? 'Cmd' : 'Win',
+                UniversalKey.leftCommand,
+              ),
+              _buildQuickKeyButton('Caps Lock', UniversalKey.capsLock),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildQuickKeyButton(String label, UniversalKey key) {
+    return ElevatedButton(
+      onPressed: () {
+        BixatKeyMouse.simulateKey(key: key, direction: Direction.click);
+        _updateStatus('$label key clicked');
+      },
+      child: Text(label),
+    );
+  }
+
+  List<UniversalKey> _getCommonKeys() {
+    return [
+      // Letters
+      UniversalKey.a, UniversalKey.b, UniversalKey.c, UniversalKey.d,
+      UniversalKey.e, UniversalKey.f, UniversalKey.g, UniversalKey.h,
+      // Numbers
+      UniversalKey.num0, UniversalKey.num1, UniversalKey.num2,
+      UniversalKey.num3, UniversalKey.num4, UniversalKey.num5,
+      // Special
+      UniversalKey.returnKey, UniversalKey.space, UniversalKey.tab,
+      UniversalKey.escape, UniversalKey.delete,
+      // Arrows
+      UniversalKey.arrowUp, UniversalKey.arrowDown,
+      UniversalKey.arrowLeft, UniversalKey.arrowRight,
+      // Modifiers
+      UniversalKey.leftControl, UniversalKey.leftShift,
+      UniversalKey.leftAlt, UniversalKey.leftCommand,
+      // Function keys
+      UniversalKey.f1, UniversalKey.f2, UniversalKey.f3, UniversalKey.f4,
+    ];
+  }
+
+  Widget _buildTextInputTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            '📝 Text Input Automation',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Automatically type text into any application.',
+            style: TextStyle(color: Colors.grey),
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: _textController,
+            maxLines: 5,
+            decoration: const InputDecoration(
+              labelText: 'Text to Type',
+              border: OutlineInputBorder(),
+              hintText: 'Enter the text you want to type automatically...',
+              helperText: 'This text will be typed character by character',
+            ),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: _typeText,
+            icon: const Icon(Icons.text_fields),
+            label: const Text('Type Text'),
+            style: ElevatedButton.styleFrom(padding: const EdgeInsets.all(16)),
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text(
+            'Quick Text Presets',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          _buildTextPresetButton('Hello World', 'Hello, World!'),
+          const SizedBox(height: 8),
+          _buildTextPresetButton(
+            'Email Template',
+            'Dear Sir/Madam,\n\nThank you for your email.\n\nBest regards,',
+          ),
+          const SizedBox(height: 8),
+          _buildTextPresetButton(
+            'Lorem Ipsum',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+          ),
+          const SizedBox(height: 8),
+          _buildTextPresetButton(
+            'Code Snippet',
+            'function hello() {\n  console.log("Hello from Bixat!");\n}',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextPresetButton(String label, String text) {
+    return ElevatedButton(
+      onPressed: () {
+        BixatKeyMouse.enterText(text: text);
+        _updateStatus('Typed: $label');
+      },
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.all(16),
+        alignment: Alignment.centerLeft,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
+          const SizedBox(height: 4),
+          Text(
+            text.length > 50 ? '${text.substring(0, 50)}...' : text,
+            style: const TextStyle(fontSize: 12, color: Colors.grey),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAutomationTab() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            '🤖 Automation & Key Combinations',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Execute complex automation sequences and key combinations.',
+            style: TextStyle(color: Colors.grey),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            'Common Key Combinations',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          _buildComboCard(
+            'Copy-Paste Automation',
+            'Select All → Copy → Paste',
+            Icons.content_copy,
+            Colors.blue,
+            _performCopyPaste,
+          ),
+          const SizedBox(height: 12),
+          _buildComboCard(
+            Platform.isMacOS ? 'Cmd+C (Copy)' : 'Ctrl+C (Copy)',
+            'Copy selected content',
+            Icons.copy,
+            Colors.green,
+            () => _performCustomCombo([
+              Platform.isMacOS
+                  ? UniversalKey.leftCommand
+                  : UniversalKey.leftControl,
+              UniversalKey.c,
+            ], 'Copy command executed'),
+          ),
+          const SizedBox(height: 12),
+          _buildComboCard(
+            Platform.isMacOS ? 'Cmd+V (Paste)' : 'Ctrl+V (Paste)',
+            'Paste clipboard content',
+            Icons.paste,
+            Colors.orange,
+            () => _performCustomCombo([
+              Platform.isMacOS
+                  ? UniversalKey.leftCommand
+                  : UniversalKey.leftControl,
+              UniversalKey.v,
+            ], 'Paste command executed'),
+          ),
+          const SizedBox(height: 12),
+          _buildComboCard(
+            Platform.isMacOS ? 'Cmd+Z (Undo)' : 'Ctrl+Z (Undo)',
+            'Undo last action',
+            Icons.undo,
+            Colors.purple,
+            () => _performCustomCombo([
+              Platform.isMacOS
+                  ? UniversalKey.leftCommand
+                  : UniversalKey.leftControl,
+              UniversalKey.z,
+            ], 'Undo command executed'),
+          ),
+          const SizedBox(height: 12),
+          _buildComboCard(
+            Platform.isMacOS ? 'Cmd+S (Save)' : 'Ctrl+S (Save)',
+            'Save current document',
+            Icons.save,
+            Colors.teal,
+            () => _performCustomCombo([
+              Platform.isMacOS
+                  ? UniversalKey.leftCommand
+                  : UniversalKey.leftControl,
+              UniversalKey.s,
+            ], 'Save command executed'),
+          ),
+          const SizedBox(height: 12),
+          _buildComboCard(
+            Platform.isMacOS ? 'Cmd+F (Find)' : 'Ctrl+F (Find)',
+            'Open find dialog',
+            Icons.search,
+            Colors.indigo,
+            () => _performCustomCombo([
+              Platform.isMacOS
+                  ? UniversalKey.leftCommand
+                  : UniversalKey.leftControl,
+              UniversalKey.f,
+            ], 'Find command executed'),
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text(
+            'Platform Information',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildInfoRow('Platform', Platform.operatingSystem),
+                  const Divider(),
+                  _buildInfoRow(
+                    'Modifier Key',
+                    Platform.isMacOS ? 'Command (⌘)' : 'Control (Ctrl)',
+                  ),
+                  const Divider(),
+                  _buildInfoRow(
+                    'Total Keys Supported',
+                    '${UniversalKey.values.length} keys',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComboCard(
+    String title,
+    String description,
+    IconData icon,
+    Color color,
+    VoidCallback onPressed,
+  ) {
+    return Card(
+      child: InkWell(
+        onTap: onPressed,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: color.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(icon, color: color, size: 32),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      description,
+                      style: const TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.play_arrow),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
+          Text(value),
+        ],
+      ),
+    );
   }
 }

--- a/example/macos/Podfile
+++ b/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/lib/src/key_code_manager.dart
+++ b/lib/src/key_code_manager.dart
@@ -57,19 +57,55 @@ class MacOSKeyCode implements PlatformKeyCode {
     UniversalKey.num9: KeyCode.ansi9,
     UniversalKey.num0: KeyCode.ansi0,
 
+    // Symbols
+    UniversalKey.equal: KeyCode.ansiEqual,
+    UniversalKey.minus: KeyCode.ansiMinus,
+    UniversalKey.rightBracket: KeyCode.ansiRightBracket,
+    UniversalKey.leftBracket: KeyCode.ansiLeftBracket,
+    UniversalKey.quote: KeyCode.ansiQuote,
+    UniversalKey.semicolon: KeyCode.ansiSemicolon,
+    UniversalKey.backslash: KeyCode.ansiBackslash,
+    UniversalKey.comma: KeyCode.ansiComma,
+    UniversalKey.slash: KeyCode.ansiSlash,
+    UniversalKey.period: KeyCode.ansiPeriod,
+    UniversalKey.grave: KeyCode.ansiGrave,
+
+    // Numpad
+    UniversalKey.numPadDecimal: KeyCode.ansiKeypadDecimal,
+    UniversalKey.numPadMultiply: KeyCode.ansiKeypadMultiply,
+    UniversalKey.numPadAdd: KeyCode.ansiKeypadPlus,
+    UniversalKey.numPadDivide: KeyCode.ansiKeypadDivide,
+    UniversalKey.numPadEnter: KeyCode.ansiKeypadEnter,
+    UniversalKey.numPadSubtract: KeyCode.ansiKeypadMinus,
+    UniversalKey.numPad0: KeyCode.ansiKeypad0,
+    UniversalKey.numPad1: KeyCode.ansiKeypad1,
+    UniversalKey.numPad2: KeyCode.ansiKeypad2,
+    UniversalKey.numPad3: KeyCode.ansiKeypad3,
+    UniversalKey.numPad4: KeyCode.ansiKeypad4,
+    UniversalKey.numPad5: KeyCode.ansiKeypad5,
+    UniversalKey.numPad6: KeyCode.ansiKeypad6,
+    UniversalKey.numPad7: KeyCode.ansiKeypad7,
+    UniversalKey.numPad8: KeyCode.ansiKeypad8,
+    UniversalKey.numPad9: KeyCode.ansiKeypad9,
+
     // Special keys
     UniversalKey.returnKey: KeyCode.returnKey,
     UniversalKey.tab: KeyCode.tabKey,
     UniversalKey.space: KeyCode.spaceKey,
     UniversalKey.delete: KeyCode.deleteKey,
     UniversalKey.escape: KeyCode.escapeKey,
-    UniversalKey.numPadEnter: KeyCode.ansiKeypadEnter,
-    UniversalKey.numPadDivide: KeyCode.ansiKeypadDivide,
-    UniversalKey.numPadMultiply: KeyCode.ansiKeypadMultiply,
-    UniversalKey.leftControl: KeyCode.rightControl,
-    UniversalKey.rightControl: KeyCode.rightControl,
-    UniversalKey.rightCommand: KeyCode.rightCommand,
+
+    // Modifiers
+    UniversalKey.leftControl: KeyCode.controlKey,
+    UniversalKey.leftShift: KeyCode.shiftKey,
+    UniversalKey.leftAlt: KeyCode.optionKey,
     UniversalKey.leftCommand: KeyCode.commandKey,
+    UniversalKey.rightControl: KeyCode.rightControl,
+    UniversalKey.rightShift: KeyCode.rightShift,
+    UniversalKey.rightAlt: KeyCode.rightOption,
+    UniversalKey.rightCommand: KeyCode.rightCommand,
+    UniversalKey.capsLock: KeyCode.capsLock,
+    UniversalKey.function: KeyCode.functionKey,
 
     // Function keys
     UniversalKey.f1: KeyCode.f1,
@@ -84,12 +120,33 @@ class MacOSKeyCode implements PlatformKeyCode {
     UniversalKey.f10: KeyCode.f10,
     UniversalKey.f11: KeyCode.f11,
     UniversalKey.f12: KeyCode.f12,
+    UniversalKey.f13: KeyCode.f13,
+    UniversalKey.f14: KeyCode.f14,
+    UniversalKey.f15: KeyCode.f15,
+    UniversalKey.f16: KeyCode.f16,
+    UniversalKey.f17: KeyCode.f17,
+    UniversalKey.f18: KeyCode.f18,
+    UniversalKey.f19: KeyCode.f19,
+    UniversalKey.f20: KeyCode.f20,
 
     // Arrow keys
     UniversalKey.arrowLeft: KeyCode.leftArrow,
     UniversalKey.arrowRight: KeyCode.rightArrow,
     UniversalKey.arrowUp: KeyCode.upArrow,
     UniversalKey.arrowDown: KeyCode.downArrow,
+
+    // Navigation
+    UniversalKey.home: KeyCode.homeKey,
+    UniversalKey.end: KeyCode.endKey,
+    UniversalKey.pageUp: KeyCode.pageUp,
+    UniversalKey.pageDown: KeyCode.pageDown,
+    UniversalKey.help: KeyCode.helpKey,
+    UniversalKey.forwardDelete: KeyCode.forwardDelete,
+
+    // Media
+    UniversalKey.volumeUp: KeyCode.volumeUp,
+    UniversalKey.volumeDown: KeyCode.volumeDown,
+    UniversalKey.mute: KeyCode.muteKey,
   };
 
   static final Map<int, UniversalKey> _reverseMap = {
@@ -159,12 +216,54 @@ class WindowsKeyCode implements PlatformKeyCode {
     UniversalKey.num9: KeyCodeWindows.vk9,
     UniversalKey.num0: KeyCodeWindows.vk0,
 
+    // Symbols
+    UniversalKey.equal: KeyCodeWindows.vkEqual,
+    UniversalKey.minus: KeyCodeWindows.vkMinus,
+    UniversalKey.rightBracket: KeyCodeWindows.vkRightBracket,
+    UniversalKey.leftBracket: KeyCodeWindows.vkLeftBracket,
+    UniversalKey.quote: KeyCodeWindows.vkQuote,
+    UniversalKey.semicolon: KeyCodeWindows.vkSemicolon,
+    UniversalKey.backslash: KeyCodeWindows.vkBackslash,
+    UniversalKey.comma: KeyCodeWindows.vkComma,
+    UniversalKey.slash: KeyCodeWindows.vkSlash,
+    UniversalKey.period: KeyCodeWindows.vkPeriod,
+    UniversalKey.grave: KeyCodeWindows.vkGrave,
+
+    // Numpad
+    UniversalKey.numPadDecimal: KeyCodeWindows.vkNumPadDecimal,
+    UniversalKey.numPadMultiply: KeyCodeWindows.vkNumPadMultiply,
+    UniversalKey.numPadAdd: KeyCodeWindows.vkNumPadAdd,
+    UniversalKey.numPadDivide: KeyCodeWindows.vkNumPadDivide,
+    UniversalKey.numPadEnter: KeyCodeWindows.vkNumPadEnter,
+    UniversalKey.numPadSubtract: KeyCodeWindows.vkNumPadSubtract,
+    UniversalKey.numPad0: KeyCodeWindows.vkNumPad0,
+    UniversalKey.numPad1: KeyCodeWindows.vkNumPad1,
+    UniversalKey.numPad2: KeyCodeWindows.vkNumPad2,
+    UniversalKey.numPad3: KeyCodeWindows.vkNumPad3,
+    UniversalKey.numPad4: KeyCodeWindows.vkNumPad4,
+    UniversalKey.numPad5: KeyCodeWindows.vkNumPad5,
+    UniversalKey.numPad6: KeyCodeWindows.vkNumPad6,
+    UniversalKey.numPad7: KeyCodeWindows.vkNumPad7,
+    UniversalKey.numPad8: KeyCodeWindows.vkNumPad8,
+    UniversalKey.numPad9: KeyCodeWindows.vkNumPad9,
+
     // Special keys
     UniversalKey.returnKey: KeyCodeWindows.vkReturn,
     UniversalKey.tab: KeyCodeWindows.vkTab,
     UniversalKey.space: KeyCodeWindows.vkSpace,
     UniversalKey.delete: KeyCodeWindows.vkDelete,
     UniversalKey.escape: KeyCodeWindows.vkEscape,
+
+    // Modifiers
+    UniversalKey.leftControl: KeyCodeWindows.vkLeftControl,
+    UniversalKey.leftShift: KeyCodeWindows.vkLeftShift,
+    UniversalKey.leftAlt: KeyCodeWindows.vkLeftAlt,
+    UniversalKey.leftCommand: KeyCodeWindows.vkLeftWin,
+    UniversalKey.rightControl: KeyCodeWindows.vkRightControl,
+    UniversalKey.rightShift: KeyCodeWindows.vkRightShift,
+    UniversalKey.rightAlt: KeyCodeWindows.vkRightAlt,
+    UniversalKey.rightCommand: KeyCodeWindows.vkRightWin,
+    UniversalKey.function: KeyCodeWindows.vkFunction,
 
     // Function keys
     UniversalKey.f1: KeyCodeWindows.vkF1,
@@ -185,6 +284,17 @@ class WindowsKeyCode implements PlatformKeyCode {
     UniversalKey.arrowRight: KeyCodeWindows.vkArrowRight,
     UniversalKey.arrowUp: KeyCodeWindows.vkArrowUp,
     UniversalKey.arrowDown: KeyCodeWindows.vkArrowDown,
+
+    // Navigation
+    UniversalKey.home: KeyCodeWindows.vkHome,
+    UniversalKey.end: KeyCodeWindows.vkEnd,
+    UniversalKey.pageUp: KeyCodeWindows.vkPageUp,
+    UniversalKey.pageDown: KeyCodeWindows.vkPageDown,
+
+    // Media
+    UniversalKey.volumeUp: KeyCodeWindows.vkVolumeUp,
+    UniversalKey.volumeDown: KeyCodeWindows.vkVolumeDown,
+    UniversalKey.mute: KeyCodeWindows.vkMute,
   };
 
   static final Map<int, UniversalKey> _reverseMap = {
@@ -254,12 +364,54 @@ class LinuxKeyCode implements PlatformKeyCode {
     UniversalKey.num9: KeyCodeLinux.xk9,
     UniversalKey.num0: KeyCodeLinux.xk0,
 
+    // Symbols
+    UniversalKey.equal: KeyCodeLinux.xkEqual,
+    UniversalKey.minus: KeyCodeLinux.xkMinus,
+    UniversalKey.rightBracket: KeyCodeLinux.xkRightBracket,
+    UniversalKey.leftBracket: KeyCodeLinux.xkLeftBracket,
+    UniversalKey.quote: KeyCodeLinux.xkQuote,
+    UniversalKey.semicolon: KeyCodeLinux.xkSemicolon,
+    UniversalKey.backslash: KeyCodeLinux.xkBackslash,
+    UniversalKey.comma: KeyCodeLinux.xkComma,
+    UniversalKey.slash: KeyCodeLinux.xkSlash,
+    UniversalKey.period: KeyCodeLinux.xkPeriod,
+    UniversalKey.grave: KeyCodeLinux.xkGrave,
+
+    // Numpad
+    UniversalKey.numPadDecimal: KeyCodeLinux.xkNumPadDecimal,
+    UniversalKey.numPadMultiply: KeyCodeLinux.xkNumPadMultiply,
+    UniversalKey.numPadAdd: KeyCodeLinux.xkNumPadAdd,
+    UniversalKey.numPadDivide: KeyCodeLinux.xkNumPadDivide,
+    UniversalKey.numPadEnter: KeyCodeLinux.xkNumPadEnter,
+    UniversalKey.numPadSubtract: KeyCodeLinux.xkNumPadSubtract,
+    UniversalKey.numPad0: KeyCodeLinux.xkNumPad0,
+    UniversalKey.numPad1: KeyCodeLinux.xkNumPad1,
+    UniversalKey.numPad2: KeyCodeLinux.xkNumPad2,
+    UniversalKey.numPad3: KeyCodeLinux.xkNumPad3,
+    UniversalKey.numPad4: KeyCodeLinux.xkNumPad4,
+    UniversalKey.numPad5: KeyCodeLinux.xkNumPad5,
+    UniversalKey.numPad6: KeyCodeLinux.xkNumPad6,
+    UniversalKey.numPad7: KeyCodeLinux.xkNumPad7,
+    UniversalKey.numPad8: KeyCodeLinux.xkNumPad8,
+    UniversalKey.numPad9: KeyCodeLinux.xkNumPad9,
+
     // Special keys
     UniversalKey.returnKey: KeyCodeLinux.xkReturn,
     UniversalKey.tab: KeyCodeLinux.xkTab,
     UniversalKey.space: KeyCodeLinux.xkSpace,
     UniversalKey.delete: KeyCodeLinux.xkDelete,
     UniversalKey.escape: KeyCodeLinux.xkEscape,
+
+    // Modifiers
+    UniversalKey.leftControl: KeyCodeLinux.xkLeftControl,
+    UniversalKey.leftShift: KeyCodeLinux.xkLeftShift,
+    UniversalKey.leftAlt: KeyCodeLinux.xkLeftAlt,
+    UniversalKey.leftCommand: KeyCodeLinux.xkLeftWin,
+    UniversalKey.rightControl: KeyCodeLinux.xkRightControl,
+    UniversalKey.rightShift: KeyCodeLinux.xkRightShift,
+    UniversalKey.rightAlt: KeyCodeLinux.xkRightAlt,
+    UniversalKey.rightCommand: KeyCodeLinux.xkRightWin,
+    UniversalKey.function: KeyCodeLinux.xkFunction,
 
     // Function keys
     UniversalKey.f1: KeyCodeLinux.xkF1,
@@ -280,6 +432,17 @@ class LinuxKeyCode implements PlatformKeyCode {
     UniversalKey.arrowRight: KeyCodeLinux.xkArrowRight,
     UniversalKey.arrowUp: KeyCodeLinux.xkArrowUp,
     UniversalKey.arrowDown: KeyCodeLinux.xkArrowDown,
+
+    // Navigation
+    UniversalKey.home: KeyCodeLinux.xkHome,
+    UniversalKey.end: KeyCodeLinux.xkEnd,
+    UniversalKey.pageUp: KeyCodeLinux.xkPageUp,
+    UniversalKey.pageDown: KeyCodeLinux.xkPageDown,
+
+    // Media
+    UniversalKey.volumeUp: KeyCodeLinux.xkVolumeUp,
+    UniversalKey.volumeDown: KeyCodeLinux.xkVolumeDown,
+    UniversalKey.mute: KeyCodeLinux.xkMute,
   };
 
   static final Map<int, UniversalKey> _reverseMap = {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bixat_key_mouse
 description: "This package allows users to control mouse and keyboard on desktop platforms."
-version: 1.0.2
+version: 1.0.3
 homepage: https://bixat.dev
 repository: https://github.com/bixat/bixat_key_mouse
 issue_tracker: https://github.com/bixat/bixat_key_mouse/issues
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_rust_bridge: 2.11.1
+  flutter_rust_bridge: ^2.11.1
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
- Expand macOS key support from 56 to 103 keys
- Expand Windows/Linux key support from 56 to 95 keys
- Add symbols, numpad, modifiers, navigation, and media keys
- Update documentation with detailed examples and API reference